### PR TITLE
Mod: Uso de next-font de dependencia a built-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@calcom/embed-react": "^1.0.9",
-    "@next/font": "^13.3.0",
     "@svgr/webpack": "^6.5.1",
     "next": "^13.3.1",
     "next-themes": "^0.2.1",


### PR DESCRIPTION
**Lo que hice:**

Eliminé a next-font como dependencia, porque Next lo trae como built-in

**Commits:**

- [mod] uso de next-font de dependencia a built-in